### PR TITLE
Correctly set gzip flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
       run: |
         mkdir -p build/darwin build/linux
         GOOS=linux GOARCH=amd64 go build -o build/linux/gha-token
-        tar -c -C build/linux -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_linux_amd64.tar.gz gha-token
+        tar -z -c -C build/linux -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_linux_amd64.tar.gz gha-token
         GOOS=darwin GOARCH=amd64 go build -o build/darwin/gha-token
-        tar -c -C build/darwin -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_darwin_amd64.tar.gz gha-token
+        tar -z -c -C build/darwin -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_darwin_amd64.tar.gz gha-token
 
     - name: Create Release Tag
       uses: actions/github-script@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,12 @@ jobs:
         mkdir -p build/darwin build/linux
         GOOS=linux GOARCH=amd64 go build -o build/linux/gha-token
         tar -z -c -C build/linux -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_linux_amd64.tar.gz gha-token
+        GOOS=linux GOARCH=arm64 go build -o build/linux/gha-token
+        tar -z -c -C build/linux -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_linux_arm64.tar.gz gha-token
         GOOS=darwin GOARCH=amd64 go build -o build/darwin/gha-token
         tar -z -c -C build/darwin -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_darwin_amd64.tar.gz gha-token
+        GOOS=darwin GOARCH=arm64 go build -o build/darwin/gha-token
+        tar -z -c -C build/darwin -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_darwin_arm64.tar.gz gha-token
 
     - name: Create Release Tag
       uses: actions/github-script@v3


### PR DESCRIPTION
The current resulting artifacts are produced without the `-z` option, and that makes some tools (e.g., go-getter) unable to parse the file in the right format (because the file extension says it's gzipped while it's not actually).