### PR TITLE
Build binaries for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,13 @@ jobs:
 
     - name: Create Release Artifacts
       run: |
-        mkdir -p build/darwin build/linux
+        mkdir -p build/darwin build/linux build/windows
         GOOS=linux GOARCH=amd64 go build -o build/linux/gha-token
         tar -c -C build/linux -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_linux_amd64.tar.gz gha-token
         GOOS=darwin GOARCH=amd64 go build -o build/darwin/gha-token
         tar -c -C build/darwin -f build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_darwin_amd64.tar.gz gha-token
+        GOOS=windows GOARCH=amd64 go build -o build/windows/gha-token.exe
+        zip -j -q build/gha-token_${{ steps.get-release-version.outputs.RELEASE_VERSION }}_windows_amd64.zip build/windows/gha-token.exe
 
     - name: Create Release Tag
       uses: actions/github-script@v3
@@ -75,7 +77,7 @@ jobs:
     - name: Publish Release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "build/*.tar.gz"
+        artifacts: "build/*.tar.gz,build/*.zip"
         name: "${{ steps.get-release-version.outputs.RELEASE_VERSION }}"
         body: "${{ steps.get-release-notes.outputs.RELEASE_NOTES }}"
         tag: "${{ steps.get-release-version.outputs.RELEASE_VERSION }}"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -i -H "Authorization: token ${TOKEN}" https://api.github.com/repos/me/myrep
 ## Releases
 
 Looking for pre-built binaries? You can find them on the [Releases](https://github.com/slawekzachcial/gha-token/releases)
-page. Currently 64-bit Linux and MacOS are available.
+page. Currently 64-bit Linux, MacOS and Windows are available.
 
 ## Generating JWT Tokens
 
@@ -157,6 +157,7 @@ To build for multiple platforms:
 mkdir -p build
 GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/gha-token
 GOOS=darwin GOARCH=amd64 go build -o build/darwin/amd64/gha-token
+GOOS=windows GOARCH=amd64 go build -o build/windows/amd64/gha-token
 ```
 
 ## GitHub Actions

--- a/gha-token.go
+++ b/gha-token.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	logger "log"
 	"net/http"
 	"net/http/httputil"
@@ -103,7 +103,7 @@ func parseFlags() config {
 }
 
 func getJwtToken(appID string, keyPath string, expSecs int) (string, error) {
-	keyBytes, err := ioutil.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return "", err
 	}
@@ -175,7 +175,7 @@ func httpJSON(method string, url string, authorization string, result interface{
 		return fmt.Errorf("Expected HTTP status code 2xx but got %d", resp.StatusCode)
 	}
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Upon release create binaries for windows as well (they are zipped instead of tared)

Replaced calls to [io/iotils](https://pkg.go.dev/io/ioutil) since they are deprecated since v1.16 (linter was failing)